### PR TITLE
feat: make continuation stability configurable

### DIFF
--- a/config/CO2_5.yaml
+++ b/config/CO2_5.yaml
@@ -42,5 +42,10 @@ abaque:
   temperature_range: [3500, 5500]
   temperature_points: 10
 
+continuation:
+  wall_temperature_stable: 3100.0
+  edge_temperature_stable: 3100.0
+  pressure_stable: 7000.0
+
 # ./blast config/default.yaml test_output
 # python3 scripts/postprocess_blast.py --input test_outputs/simulation_20250713_232651.h5 --plots all --output results_h5

--- a/include/blast/boundary_layer/solver/continuation_method.hpp
+++ b/include/blast/boundary_layer/solver/continuation_method.hpp
@@ -19,16 +19,6 @@ class ContinuationMethod {
 public:
   ContinuationMethod() = default;
 
-  // Hardcoded stable conditions (exposed for solver use)
-  /*     static constexpr double TWALL_STABLE = 3100.0;
-      static constexpr double TEDGE_STABLE = 5905.0; */
-  static constexpr double TWALL_STABLE = 3100.0;
-  static constexpr double TEDGE_STABLE = 3100.0;
-  static constexpr double PRESSURE_STABLE = 7000.0;
-/*   static constexpr double TWALL_STABLE = 300.0;
-  static constexpr double TEDGE_STABLE = 300.0;
-  static constexpr double PRESSURE_STABLE = 10000.0; */
-
   [[nodiscard]] auto solve_with_continuation(
       BoundaryLayerSolver& solver, int station, double xi, const io::Configuration& target_config,
       const equations::SolutionState& initial_guess) -> std::expected<ContinuationResult, SolverError>;

--- a/include/blast/io/config_types.hpp
+++ b/include/blast/io/config_types.hpp
@@ -91,6 +91,12 @@ struct AbaqueConfig {
   int temperature_points = 100;
 };
 
+struct ContinuationConfig {
+  double wall_temperature_stable = 3100.0;
+  double edge_temperature_stable = 3100.0;
+  double pressure_stable = 7000.0;
+};
+
 struct Configuration {
   SimulationConfig simulation;
   NumericalConfig numerical;
@@ -100,6 +106,7 @@ struct Configuration {
   OuterEdgeConfig outer_edge;
   WallParametersConfig wall_parameters;
   AbaqueConfig abaque;
+  ContinuationConfig continuation;
 };
 
 template <typename T>

--- a/include/blast/io/yaml_parser.hpp
+++ b/include/blast/io/yaml_parser.hpp
@@ -45,8 +45,11 @@ private:
   [[nodiscard]] auto parse_wall_parameters_config(const YAML::Node& node) const
       -> std::expected<WallParametersConfig, core::ConfigurationError>;
 
-  [[nodiscard]] auto parse_abaque_config(const YAML::Node& node) const 
+  [[nodiscard]] auto parse_abaque_config(const YAML::Node& node) const
     -> std::expected<AbaqueConfig, core::ConfigurationError>;
+
+  [[nodiscard]] auto parse_continuation_config(const YAML::Node& node) const
+      -> std::expected<ContinuationConfig, core::ConfigurationError>;
 
 public:
   explicit YamlParser(std::string file_path) : file_path_(std::move(file_path)) {} // constructor so no ->

--- a/src/boundary_layer/solver/boundary_layer_solver.cpp
+++ b/src/boundary_layer/solver/boundary_layer_solver.cpp
@@ -244,11 +244,11 @@ auto BoundaryLayerSolver::solve_station(int station, double xi, const equations:
   auto compute_stable_guess = [&]() -> std::expected<equations::SolutionState, SolverError> {
     io::Configuration stable_config = original_config_;
     if (!stable_config.wall_parameters.wall_temperatures.empty()) {
-      stable_config.wall_parameters.wall_temperatures[0] = ContinuationMethod::TWALL_STABLE;
+      stable_config.wall_parameters.wall_temperatures[0] = original_config_.continuation.wall_temperature_stable;
     }
     if (!stable_config.outer_edge.edge_points.empty()) {
-      stable_config.outer_edge.edge_points[0].temperature = ContinuationMethod::TEDGE_STABLE;
-      stable_config.outer_edge.edge_points[0].pressure = ContinuationMethod::PRESSURE_STABLE;
+      stable_config.outer_edge.edge_points[0].temperature = original_config_.continuation.edge_temperature_stable;
+      stable_config.outer_edge.edge_points[0].pressure = original_config_.continuation.pressure_stable;
     }
 
     auto bc_stable = conditions::create_stagnation_conditions(stable_config.outer_edge, stable_config.wall_parameters,

--- a/src/boundary_layer/solver/continuation_method.cpp
+++ b/src/boundary_layer/solver/continuation_method.cpp
@@ -78,7 +78,9 @@ auto ContinuationMethod::interpolate_config(const io::Configuration& target, dou
   // Interpolate wall temperature
   if (!config.wall_parameters.wall_temperatures.empty()) {
     double Twall_target = target.wall_parameters.wall_temperatures[0];
-    config.wall_parameters.wall_temperatures[0] = TWALL_STABLE + lambda * (Twall_target - TWALL_STABLE);
+    double Twall_stable = target.continuation.wall_temperature_stable;
+    config.wall_parameters.wall_temperatures[0] =
+        Twall_stable + lambda * (Twall_target - Twall_stable);
   }
 
   // Interpolate edge conditions
@@ -86,8 +88,10 @@ auto ContinuationMethod::interpolate_config(const io::Configuration& target, dou
     auto& edge = config.outer_edge.edge_points[0];
     const auto& target_edge = target.outer_edge.edge_points[0];
 
-    edge.temperature = TEDGE_STABLE + lambda * (target_edge.temperature - TEDGE_STABLE);
-    edge.pressure = PRESSURE_STABLE + lambda * (target_edge.pressure - PRESSURE_STABLE);
+    double Tedge_stable = target.continuation.edge_temperature_stable;
+    double pressure_stable = target.continuation.pressure_stable;
+    edge.temperature = Tedge_stable + lambda * (target_edge.temperature - Tedge_stable);
+    edge.pressure = pressure_stable + lambda * (target_edge.pressure - pressure_stable);
   }
 
   return config;

--- a/src/io/yaml_parser.cpp
+++ b/src/io/yaml_parser.cpp
@@ -94,6 +94,12 @@ auto YamlParser::parse() const -> std::expected<Configuration, core::Configurati
     }
     config.abaque = std::move(abaque_result.value());
 
+    auto cont_result = parse_continuation_config(root_["continuation"]);
+    if (!cont_result) {
+      return std::unexpected(cont_result.error());
+    }
+    config.continuation = std::move(cont_result.value());
+
     return config;
 
   } catch (const YAML::Exception& e) {
@@ -378,6 +384,32 @@ auto YamlParser::parse_abaque_config(const YAML::Node& node) const
     
   } catch (const YAML::Exception& e) {
     return std::unexpected(core::ConfigurationError(std::format("In 'abaque' section: {}", e.what())));
+  }
+}
+
+auto YamlParser::parse_continuation_config(const YAML::Node& node) const
+    -> std::expected<ContinuationConfig, core::ConfigurationError> {
+
+  ContinuationConfig config;
+
+  if (!node) {
+    return config;
+  }
+
+  try {
+    if (node["wall_temperature_stable"]) {
+      config.wall_temperature_stable = node["wall_temperature_stable"].as<double>();
+    }
+    if (node["edge_temperature_stable"]) {
+      config.edge_temperature_stable = node["edge_temperature_stable"].as<double>();
+    }
+    if (node["pressure_stable"]) {
+      config.pressure_stable = node["pressure_stable"].as<double>();
+    }
+    return config;
+  } catch (const YAML::Exception& e) {
+    return std::unexpected(
+        core::ConfigurationError(std::format("In 'continuation' section: failed to parse - {}", e.what())));
   }
 }
 


### PR DESCRIPTION
## Summary
- allow specifying stable wall, edge temperature and pressure via new `continuation` config node
- use configured stable values when computing initial guesses and during continuation

## Testing
- `make` *(fails: fatal error: Eigen/Dense: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899758c3e948333a1b5ebaeeda6c672