### PR TITLE
Improve error handling and numerical safeguards

### DIFF
--- a/include/blast/boundary_layer/coefficients/heat_flux_calculator.hpp
+++ b/include/blast/boundary_layer/coefficients/heat_flux_calculator.hpp
@@ -17,10 +17,10 @@ struct HeatFluxGeometryFactors {
 };
 
 // Error type for heat flux calculations
-class HeatFluxError : public core::BlastException {
+class HeatFluxError : public core::GeometryError {
 public:
   explicit HeatFluxError(std::string_view message, std::source_location location = std::source_location::current())
-      : BlastException(std::format("Heat Flux Error: {}", message), location) {}
+      : GeometryError(std::format("Heat Flux Error: {}", message), location) {}
 };
 
 class HeatFluxCalculator {
@@ -42,7 +42,8 @@ private:
 
   [[nodiscard]] auto
   compute_conductive_flux_profile(const std::vector<double>& dT_deta, const std::vector<double>& k_local,
-                                  const HeatFluxGeometryFactors& geo_factors) const -> std::vector<double>;
+                                  const HeatFluxGeometryFactors& geo_factors) const
+      -> std::expected<std::vector<double>, HeatFluxError>;
 
   [[nodiscard]] auto compute_diffusive_flux_profile(const CoefficientSet& coeffs) const
       -> std::pair<std::vector<double>, core::Matrix<double>>;

--- a/include/blast/boundary_layer/solver/adaptive_relaxation_controller.hpp
+++ b/include/blast/boundary_layer/solver/adaptive_relaxation_controller.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include "../../core/exceptions.hpp"
 #include "../equations/equation_types.hpp"
+#include "solver_errors.hpp"
 #include <algorithm>
 #include <cmath>
 #include <expected>
@@ -8,9 +9,6 @@
 #include <vector>
 
 namespace blast::boundary_layer::solver {
-
-// Forward declarations
-class SolverError;
 
 // ConvergenceInfo definition
 struct ConvergenceInfo {
@@ -85,7 +83,8 @@ public:
   }
 
   // Main method to adapt the factor
-  [[nodiscard]] auto adapt_relaxation_factor(const ConvergenceInfo& conv_info, int iteration) -> double;
+  [[nodiscard]] auto adapt_relaxation_factor(const ConvergenceInfo& conv_info,
+                                             int iteration) -> std::expected<double, RelaxationError>;
 
   // Accessors
   [[nodiscard]] auto current_factor() const noexcept -> double { return current_factor_; }
@@ -104,7 +103,7 @@ public:
 
 private:
   [[nodiscard]] auto detect_oscillations() const -> std::expected<bool, SolverError>;
-  [[nodiscard]] auto compute_residual_trend() const -> std::expected<double, SolverError>;
+  [[nodiscard]] auto compute_residual_trend() const -> std::expected<double, NumericError>;
 };
 
 // Factory functions for different problem types

--- a/include/blast/boundary_layer/solver/boundary_layer_solver.hpp
+++ b/include/blast/boundary_layer/solver/boundary_layer_solver.hpp
@@ -12,6 +12,7 @@
 #include "../thermodynamics/enthalpy_temperature_solver.hpp"
 #include "adaptive_relaxation_controller.hpp"
 #include "continuation_method.hpp"
+#include "solver_errors.hpp"
 #include "solver_steps.hpp"
 #include <expected>
 #include <memory>
@@ -35,26 +36,6 @@ struct SolutionResult {
 };
 
 // ConvergenceInfo is now defined in adaptive_relaxation_controller.hpp
-
-// Error type for solver operations
-class SolverError : public core::BlastException {
-public:
-  explicit SolverError(std::string_view message, std::source_location location = std::source_location::current())
-      : BlastException(std::format("Solver Error: {}", message), location) {}
-
-  template <typename... Args>
-  explicit SolverError(std::string_view format_str, std::source_location location, Args&&... args)
-      : BlastException(std::format("Solver Error: {}", std::vformat(format_str, std::make_format_args(args...))),
-                       location) {}
-};
-
-// Specialized error class for step execution failures
-class StepExecutionError : public SolverError {
-public:
-  explicit StepExecutionError(std::string_view step_name, std::string_view message,
-                              std::source_location location = std::source_location::current())
-      : SolverError(std::format("Step '{}' failed: {}", step_name, message), location) {}
-};
 
 class BoundaryLayerSolver {
 private:

--- a/include/blast/boundary_layer/solver/continuation_method.hpp
+++ b/include/blast/boundary_layer/solver/continuation_method.hpp
@@ -1,13 +1,13 @@
 #pragma once
 #include "../../io/config_types.hpp"
 #include "../equations/equation_types.hpp"
+#include "solver_errors.hpp"
 #include <expected>
 #include <vector>
 
 namespace blast::boundary_layer::solver {
 
 class BoundaryLayerSolver;
-class SolverError;
 
 struct ContinuationResult {
   equations::SolutionState solution;

--- a/include/blast/boundary_layer/solver/solver_errors.hpp
+++ b/include/blast/boundary_layer/solver/solver_errors.hpp
@@ -1,0 +1,43 @@
+#pragma once
+#include "../../core/exceptions.hpp"
+#include <source_location>
+#include <string_view>
+
+namespace blast::boundary_layer::solver {
+
+class SolverError : public core::BlastException {
+public:
+  explicit SolverError(std::string_view message, std::source_location location = std::source_location::current())
+      : BlastException(std::format("Solver Error: {}", message), location) {}
+};
+
+class NumericError : public SolverError {
+public:
+  explicit NumericError(std::string_view message, std::source_location location = std::source_location::current())
+      : SolverError(std::format("Numeric Error: {}", message), location) {}
+};
+
+class GeometryError : public SolverError {
+public:
+  explicit GeometryError(std::string_view message, std::source_location location = std::source_location::current())
+      : SolverError(std::format("Geometry Error: {}", message), location) {}
+};
+
+class RelaxationError : public SolverError {
+public:
+  explicit RelaxationError(std::string_view message,
+                           std::source_location location = std::source_location::current())
+      : SolverError(std::format("Relaxation Error: {}", message), location) {}
+  RelaxationError(std::string_view message, const SolverError& cause,
+                  std::source_location location = std::source_location::current())
+      : SolverError(std::format("Relaxation Error: {}: {}", message, cause.message()), location) {}
+};
+
+class StepExecutionError : public SolverError {
+public:
+  explicit StepExecutionError(std::string_view step_name, std::string_view message,
+                              std::source_location location = std::source_location::current())
+      : SolverError(std::format("Step '{}' failed: {}", step_name, message), location) {}
+};
+
+} // namespace blast::boundary_layer::solver

--- a/include/blast/boundary_layer/solver/solver_steps.hpp
+++ b/include/blast/boundary_layer/solver/solver_steps.hpp
@@ -8,6 +8,7 @@
 #include "../equations/equation_types.hpp"
 #include "../grid/grid.hpp"
 #include "../thermodynamics/enthalpy_temperature_solver.hpp"
+#include "solver_errors.hpp"
 #include <expected>
 #include <memory>
 
@@ -15,8 +16,6 @@ namespace blast::boundary_layer::solver {
 
 // Forward declarations
 class BoundaryLayerSolver;
-class SolverError;        // Forward declaration
-class StepExecutionError; // Forward declaration
 
 // =============================================================================
 // CORE STEP INTERFACES

--- a/src/boundary_layer/solver/boundary_layer_solver.cpp
+++ b/src/boundary_layer/solver/boundary_layer_solver.cpp
@@ -454,7 +454,11 @@ auto BoundaryLayerSolver::iterate_station_adaptive(int station, double xi, const
     }
 
     // Adaptive relaxation
-    double adaptive_factor = relaxation_controller_->adapt_relaxation_factor(conv_info, iter);
+    auto adaptive_factor_result = relaxation_controller_->adapt_relaxation_factor(conv_info, iter);
+    if (!adaptive_factor_result) {
+      return std::unexpected<SolverError>(adaptive_factor_result.error());
+    }
+    double adaptive_factor = adaptive_factor_result.value();
 /*     std::cout << "Adaptive relaxation factor: " << std::scientific << std::setprecision(3) << adaptive_factor
               << " (max residual: " << conv_info.max_residual() << ")" << std::endl; */
 


### PR DESCRIPTION
## Summary
- track call stack in BlastException with new Numeric and Geometry errors
- centralize solver error hierarchy and propagate RelaxationError in adaptive controller
- validate YAML `x_stations` for non-negative, ordered values

## Testing
- `make` *(fails: Eigen, yaml-cpp, and HDF5 development libraries missing)*

------
https://chatgpt.com/codex/tasks/task_e_689a725119648333bdf0a1fd26046c40