### PR TITLE
Start continuation from last converged station

### DIFF
--- a/include/blast/boundary_layer/solver/station_solver.hpp
+++ b/include/blast/boundary_layer/solver/station_solver.hpp
@@ -34,6 +34,8 @@ public:
         double wall_temperature_stable;
         double edge_temperature_stable;
         double pressure_stable;
+        double radius_stable;
+        double velocity_stable;
     };
 
     /**

--- a/include/blast/core/constants.hpp
+++ b/include/blast/core/constants.hpp
@@ -147,6 +147,12 @@ inline constexpr double stable_edge_temperature = 3100.0;
 /// Default pressure for stable conditions [Pa]
 inline constexpr double stable_pressure = 7000.0;
 
+/// Default body radius for stable conditions [m]
+inline constexpr double stable_radius = 1.0;
+
+/// Default edge velocity for stable conditions [m/s]
+inline constexpr double stable_velocity = 0.0;
+
 /// Default emissivity for non-radiating surfaces
 inline constexpr double default_emissivity = 0.0;
 

--- a/include/blast/io/config_types.hpp
+++ b/include/blast/io/config_types.hpp
@@ -130,6 +130,8 @@ struct ContinuationConfig {
   double wall_temperature_stable = constants::defaults::stable_wall_temperature;
   double edge_temperature_stable = constants::defaults::stable_edge_temperature;
   double pressure_stable = constants::defaults::stable_pressure;
+  double radius_stable = constants::defaults::stable_radius;
+  double velocity_stable = constants::defaults::stable_velocity;
 };
 
 struct EdgeReconstructionConfig {

--- a/src/boundary_layer/solver/boundary_layer_solver.cpp
+++ b/src/boundary_layer/solver/boundary_layer_solver.cpp
@@ -92,7 +92,9 @@ auto BoundaryLayerSolver::initialize_solver_components() -> void {
     StationSolver::StableGuessConfig stable_config{
       .wall_temperature_stable = original_config_.continuation.wall_temperature_stable,
       .edge_temperature_stable = original_config_.continuation.edge_temperature_stable,
-      .pressure_stable = original_config_.continuation.pressure_stable
+      .pressure_stable = original_config_.continuation.pressure_stable,
+      .radius_stable = original_config_.continuation.radius_stable,
+      .velocity_stable = original_config_.continuation.velocity_stable
     };
     station_solver_->set_stable_config(stable_config);
   }

--- a/src/boundary_layer/solver/continuation_method.cpp
+++ b/src/boundary_layer/solver/continuation_method.cpp
@@ -90,8 +90,12 @@ auto ContinuationMethod::interpolate_config(const io::Configuration& target, dou
 
     double Tedge_stable = target.continuation.edge_temperature_stable;
     double pressure_stable = target.continuation.pressure_stable;
+    double radius_stable = target.continuation.radius_stable;
+    double velocity_stable = target.continuation.velocity_stable;
     edge.temperature = Tedge_stable + lambda * (target_edge.temperature - Tedge_stable);
     edge.pressure = pressure_stable + lambda * (target_edge.pressure - pressure_stable);
+    edge.radius = radius_stable + lambda * (target_edge.radius - radius_stable);
+    edge.velocity = velocity_stable + lambda * (target_edge.velocity - velocity_stable);
   }
 
   return config;

--- a/src/boundary_layer/solver/station_solver.cpp
+++ b/src/boundary_layer/solver/station_solver.cpp
@@ -46,15 +46,42 @@ auto StationSolver::solve_station(int station, double xi, const equations::Solut
 
     if (!convergence_result) {
         // Try continuation if available and not already in continuation
-        if (auto* continuation = solver_.get_continuation(); 
+        if (auto* continuation = solver_.get_continuation();
             continuation && !in_continuation_ && should_attempt_continuation(ConvergenceError(convergence_result.error().message()))) {
-            
-            auto stable_guess = compute_stable_guess(station, xi);
-            if (stable_guess) {
-                auto cont_result = continuation->solve_with_continuation(solver_, station, xi, 
-                                                                       solver_.get_original_config(), 
-                                                                       stable_guess.value());
 
+            io::Configuration cont_config = solver_.get_original_config();
+            equations::SolutionState cont_guess;
+            bool have_guess = false;
+
+            if (station > 0) {
+                const auto& grid = solver_.get_grid();
+                double xi_prev = grid.xi_coordinates()[station - 1];
+                auto prev_bc_result = conditions::interpolate_boundary_conditions(
+                    station - 1, xi_prev, grid.xi_coordinates(), config_.outer_edge,
+                    config_.wall_parameters, config_.simulation, mixture_);
+                if (prev_bc_result) {
+                    const auto& prev_bc = prev_bc_result.value();
+                    cont_config.continuation.wall_temperature_stable = initial_guess.T[0];
+                    cont_config.continuation.edge_temperature_stable = prev_bc.edge.temperature;
+                    cont_config.continuation.pressure_stable = prev_bc.edge.pressure;
+                    cont_config.continuation.radius_stable = prev_bc.edge.body_radius;
+                    cont_config.continuation.velocity_stable = prev_bc.edge.velocity;
+                    cont_guess = initial_guess;
+                    have_guess = true;
+                }
+            }
+
+            if (!have_guess) {
+                auto stable_guess = compute_stable_guess(station, xi);
+                if (stable_guess) {
+                    cont_guess = stable_guess.value();
+                    have_guess = true;
+                }
+            }
+
+            if (have_guess) {
+                auto cont_result = continuation->solve_with_continuation(
+                    solver_, station, xi, cont_config, cont_guess);
                 if (cont_result && cont_result.value().success) {
                     return cont_result.value().solution;
                 }
@@ -81,15 +108,42 @@ auto StationSolver::solve_station(int station, double xi, const equations::Solut
         }
 
         // Try continuation for non-continuation failures
-        if (auto* continuation = solver_.get_continuation(); 
+        if (auto* continuation = solver_.get_continuation();
             continuation && !in_continuation_ && conv_info.max_residual() < 1e10) {
-            
-            auto stable_guess = compute_stable_guess(station, xi);
-            if (stable_guess) {
-                auto cont_result = continuation->solve_with_continuation(solver_, station, xi, 
-                                                                       solver_.get_original_config(), 
-                                                                       stable_guess.value());
 
+            io::Configuration cont_config = solver_.get_original_config();
+            equations::SolutionState cont_guess;
+            bool have_guess = false;
+
+            if (station > 0) {
+                const auto& grid = solver_.get_grid();
+                double xi_prev = grid.xi_coordinates()[station - 1];
+                auto prev_bc_result = conditions::interpolate_boundary_conditions(
+                    station - 1, xi_prev, grid.xi_coordinates(), config_.outer_edge,
+                    config_.wall_parameters, config_.simulation, mixture_);
+                if (prev_bc_result) {
+                    const auto& prev_bc = prev_bc_result.value();
+                    cont_config.continuation.wall_temperature_stable = initial_guess.T[0];
+                    cont_config.continuation.edge_temperature_stable = prev_bc.edge.temperature;
+                    cont_config.continuation.pressure_stable = prev_bc.edge.pressure;
+                    cont_config.continuation.radius_stable = prev_bc.edge.body_radius;
+                    cont_config.continuation.velocity_stable = prev_bc.edge.velocity;
+                    cont_guess = initial_guess;
+                    have_guess = true;
+                }
+            }
+
+            if (!have_guess) {
+                auto stable_guess = compute_stable_guess(station, xi);
+                if (stable_guess) {
+                    cont_guess = stable_guess.value();
+                    have_guess = true;
+                }
+            }
+
+            if (have_guess) {
+                auto cont_result = continuation->solve_with_continuation(
+                    solver_, station, xi, cont_config, cont_guess);
                 if (cont_result && cont_result.value().success) {
                     return cont_result.value().solution;
                 }
@@ -97,7 +151,7 @@ auto StationSolver::solve_station(int station, double xi, const equations::Solut
         }
 
         return std::unexpected(
-            ConvergenceError(std::format("Station {} failed to converge after {} iterations (residual={})", 
+            ConvergenceError(std::format("Station {} failed to converge after {} iterations (residual={})",
                                         station, conv_info.iterations, conv_info.max_residual())));
     }
 
@@ -141,6 +195,8 @@ auto StationSolver::compute_stable_guess(int station, double xi) const
     if (!stable_config.outer_edge.edge_points.empty()) {
         stable_config.outer_edge.edge_points[0].temperature = stable_config_.edge_temperature_stable;
         stable_config.outer_edge.edge_points[0].pressure = stable_config_.pressure_stable;
+        stable_config.outer_edge.edge_points[0].radius = stable_config_.radius_stable;
+        stable_config.outer_edge.edge_points[0].velocity = stable_config_.velocity_stable;
     }
 
     // Get stable boundary conditions

--- a/src/io/yaml_parser.cpp
+++ b/src/io/yaml_parser.cpp
@@ -813,6 +813,12 @@ auto YamlParser::parse_continuation_config(const YAML::Node& node) const
     if (node["pressure_stable"]) {
       config.pressure_stable = node["pressure_stable"].as<double>();
     }
+    if (node["radius_stable"]) {
+      config.radius_stable = node["radius_stable"].as<double>();
+    }
+    if (node["velocity_stable"]) {
+      config.velocity_stable = node["velocity_stable"].as<double>();
+    }
     return config;
   } catch (const YAML::Exception& e) {
     return std::unexpected(


### PR DESCRIPTION
## Summary
- Extend continuation configuration with stable radius and velocity defaults
- Start continuation from the last converged station's boundary conditions and solution
- Interpolate edge radius and velocity during continuation steps

## Testing
- `make` *(fails: HDF5 development libraries not found)*

------
https://chatgpt.com/codex/tasks/task_e_68addeac92e88333abd6d8e930c1bc9b